### PR TITLE
Store pull request review data

### DIFF
--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1,6 +1,7 @@
 class Host < ApplicationRecord
   has_many :repositories
   has_many :issues
+  has_many :reviews
   has_many :owners
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }

--- a/app/models/hosts/base.rb
+++ b/app/models/hosts/base.rb
@@ -61,6 +61,10 @@ module Hosts
       "#{url(repository)}/issues"
     end
 
+    def load_reviews(repository)
+      yield []
+    end
+
     def source_url(repository)
       "#{@host.url}/#{repository.source_name}"
     end

--- a/app/models/hosts/gitea.rb
+++ b/app/models/hosts/gitea.rb
@@ -49,6 +49,31 @@ module Hosts
       end
     end
 
+    def load_reviews(repository)
+      repository.issues.pull_request.find_each do |pull_request|
+        resp = api_client.get("/api/v1/repos/#{repository.full_name}/pulls/#{pull_request.number}/reviews", {limit: 100})
+        next unless resp.success?
+
+        yield resp.body.map { |review| map_review(review, pull_request.number) }
+      end
+    rescue *IGNORABLE_EXCEPTIONS
+      # pull requests may not be enabled
+    end
+
+    def map_review(review, pull_request_number)
+      {
+        uuid: review['id'],
+        node_id: nil,
+        pull_request_number: pull_request_number,
+        user: review.dig('user', 'login'),
+        state: review['state'],
+        author_association: nil,
+        body: review['body'],
+        commit_id: review['commit_id'],
+        submitted_at: review['submitted_at'] || review['updated_at']
+      }
+    end
+
     def api_client
       Faraday.new(@host.url, request: {timeout: 30}) do |conn|
         conn.request :authorization, :bearer, REDIS.get("gitea_token:#{@host.id}")

--- a/app/models/hosts/github.rb
+++ b/app/models/hosts/github.rb
@@ -86,6 +86,35 @@ module Hosts
       end 
     end
 
+    def load_reviews(repository)
+      repository.issues.pull_request.find_each do |pull_request|
+        reviews = api_client.pull_request_reviews(repository.full_name, pull_request.number)
+
+        while reviews.present?
+          yield map_reviews(reviews, pull_request.number)
+
+          break unless reviews.respond_to?(:next_page) && reviews.next_page.present?
+          reviews = reviews.next_page
+        end
+      end
+    end
+
+    def map_reviews(data, pull_request_number)
+      data.map do |review|
+        {
+          uuid: review.id,
+          node_id: review.node_id,
+          pull_request_number: pull_request_number,
+          user: review.user&.login,
+          state: review.state,
+          author_association: review.author_association,
+          body: review.body,
+          commit_id: review.commit_id,
+          submitted_at: review.submitted_at
+        }
+      end
+    end
+
     def map_issues(data)
       data.map do |issue|
         {

--- a/app/models/hosts/gitlab.rb
+++ b/app/models/hosts/gitlab.rb
@@ -70,6 +70,36 @@ module Hosts
       # merge requests may not be not enabled
     end
 
+    def load_reviews(repository)
+      repository.issues.pull_request.find_each do |merge_request|
+        notes = api_client.merge_request_notes(repository.full_name, merge_request.number, per_page: 100)
+
+        while notes.present?
+          review_notes = notes.select { |note| note.system == false }
+          yield review_notes.map { |note| map_review_note(note, merge_request.number) }
+
+          break unless notes.respond_to?(:next_page) && notes.next_page.present?
+          notes = notes.next_page
+        end
+      end
+    rescue *IGNORABLE_EXCEPTIONS
+      # merge requests may not be enabled
+    end
+
+    def map_review_note(note, merge_request_number)
+      {
+        uuid: note.id,
+        node_id: nil,
+        pull_request_number: merge_request_number,
+        user: note.author&.username,
+        state: 'COMMENTED',
+        author_association: nil,
+        body: note.body,
+        commit_id: nil,
+        submitted_at: note.created_at
+      }
+    end
+
     def api_client
       ::Gitlab.client(endpoint: "#{@host.url}/api/v4", private_token:  REDIS.get("gitlab_token:#{@host.id}"))
     end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -2,6 +2,7 @@ class Issue < ApplicationRecord
   belongs_to :repository
   belongs_to :host
   belongs_to :owner, ->(issue) { where(host_id: issue.host_id) }, foreign_key: :user, primary_key: :login, optional: true
+  has_many :reviews, dependent: :delete_all
 
   scope :past_year, -> { where('created_at > ?', 1.year.ago) }
   scope :bot, -> { where('issues.user ILIKE ?', '%[bot]') }

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -13,6 +13,7 @@ class Repository < ApplicationRecord
   belongs_to :host
 
   has_many :issues, dependent: :delete_all
+  has_many :reviews, dependent: :delete_all
 
   validates :full_name, presence: true
 
@@ -172,7 +173,10 @@ class Repository < ApplicationRecord
       )
     end
 
+    sync_reviews
+
     issues.reset
+    reviews.reset
     update_issue_counts
     self.status = 'active'
     self.last_synced_at = Time.now
@@ -182,6 +186,27 @@ class Repository < ApplicationRecord
     self.last_synced_at = Time.now
     self.save
     raise e
+  end
+
+  def sync_reviews
+    host.host_instance.load_reviews(self) do |data|
+      next if data.empty?
+
+      review_data = data.map do |review|
+        review_attrs = review.dup
+        review_attrs[:host_id] = host.id
+        review_attrs[:repository_id] = id
+        review_attrs[:issue_id] = issues.find_by(number: review[:pull_request_number], pull_request: true)&.id
+        review_attrs
+      end
+
+      Review.upsert_all(
+        review_data,
+        unique_by: [:host_id, :uuid],
+        update_only: [:node_id, :pull_request_number, :user, :state, :author_association,
+                      :body, :commit_id, :submitted_at, :issue_id, :updated_at]
+      )
+    end
   end
 
   def update_issue_counts

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,0 +1,8 @@
+class Review < ApplicationRecord
+  belongs_to :repository
+  belongs_to :issue, optional: true
+  belongs_to :host
+
+  scope :pull_request, ->(number) { where(pull_request_number: number) }
+  scope :state, ->(state) { where(state: state) }
+end

--- a/db/migrate/20260428205700_create_reviews.rb
+++ b/db/migrate/20260428205700_create_reviews.rb
@@ -1,0 +1,25 @@
+class CreateReviews < ActiveRecord::Migration[8.0]
+  def change
+    create_table :reviews do |t|
+      t.integer :repository_id, null: false
+      t.integer :issue_id
+      t.integer :host_id, null: false
+      t.string :uuid, null: false
+      t.string :node_id
+      t.integer :pull_request_number, null: false
+      t.string :user
+      t.string :state
+      t.string :author_association
+      t.text :body
+      t.string :commit_id
+      t.datetime :submitted_at
+
+      t.timestamps
+    end
+
+    add_index :reviews, [:host_id, :uuid], unique: true
+    add_index :reviews, [:repository_id, :pull_request_number]
+    add_index :reviews, :issue_id
+    add_index :reviews, :user
+  end
+end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -148,4 +148,38 @@ class RepositoryTest < ActiveSupport::TestCase
     assert_nil result['issue_author']
     assert_equal 1, result['pr_author']
   end
+  test "sync_reviews stores pull request review data and links pull request issue" do
+    host = create(:host)
+    repository = create(:repository, host: host)
+    pull_request = create(:issue, repository: repository, host: host, pull_request: true, number: 42)
+
+    review_payload = [{
+      uuid: 'review-1',
+      node_id: 'node-1',
+      pull_request_number: 42,
+      user: 'reviewer',
+      state: 'APPROVED',
+      author_association: 'MEMBER',
+      body: 'Looks good',
+      commit_id: 'abc123',
+      submitted_at: Time.current
+    }]
+
+    fake_host_instance = Class.new do
+      define_method(:initialize) { |payload| @payload = payload }
+      define_method(:load_reviews) { |_repository, &block| block.call(@payload) }
+    end.new(review_payload)
+
+    host.stub(:host_instance, fake_host_instance) do
+      repository.sync_reviews
+    end
+
+    review = repository.reviews.find_by!(uuid: 'review-1')
+    assert_equal host, review.host
+    assert_equal pull_request, review.issue
+    assert_equal 42, review.pull_request_number
+    assert_equal 'reviewer', review.user
+    assert_equal 'APPROVED', review.state
+  end
+
 end

--- a/test/models/review_test.rb
+++ b/test/models/review_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class ReviewTest < ActiveSupport::TestCase
+  test "belongs to repository host and optional issue" do
+    host = create(:host)
+    repository = create(:repository, host: host)
+    pull_request = create(:issue, repository: repository, host: host, pull_request: true, number: 42)
+
+    review = Review.create!(
+      host: host,
+      repository: repository,
+      issue: pull_request,
+      uuid: 'review-1',
+      pull_request_number: 42,
+      user: 'reviewer',
+      state: 'APPROVED'
+    )
+
+    assert_equal repository, review.repository
+    assert_equal host, review.host
+    assert_equal pull_request, review.issue
+    assert_equal [review], Review.pull_request(42).to_a
+    assert_equal [review], Review.state('APPROVED').to_a
+  end
+end


### PR DESCRIPTION
Fixes #196

## Summary

- Adds a `Review` model/table for pull/merge request review metadata.
- Syncs reviews after issue/PR sync and upserts them by host + upstream review id.
- Links stored reviews back to their repository, host, and PR issue row when available.
- Adds host adapters for GitHub PR reviews, GitLab merge request review-like notes, and Gitea/Forgejo pull reviews.
- Keeps non-review-capable hosts safe via a base no-op `load_reviews` implementation.

## Validation

- `/opt/homebrew/opt/ruby/bin/bundle exec ruby -c app/models/repository.rb`
- `/opt/homebrew/opt/ruby/bin/bundle exec ruby -c app/models/review.rb`
- `/opt/homebrew/opt/ruby/bin/bundle exec ruby -c app/models/issue.rb`
- `/opt/homebrew/opt/ruby/bin/bundle exec ruby -c app/models/host.rb`
- `/opt/homebrew/opt/ruby/bin/bundle exec ruby -c app/models/hosts/base.rb`
- `/opt/homebrew/opt/ruby/bin/bundle exec ruby -c app/models/hosts/github.rb`
- `/opt/homebrew/opt/ruby/bin/bundle exec ruby -c app/models/hosts/gitlab.rb`
- `/opt/homebrew/opt/ruby/bin/bundle exec ruby -c app/models/hosts/gitea.rb`
- `/opt/homebrew/opt/ruby/bin/bundle exec ruby -c db/migrate/20260428205700_create_reviews.rb`
- `git diff --check`

Note: full Rails/database tests are blocked locally because PostgreSQL is not running on `/tmp/.s.PGSQL.5432`.