### PR TITLE
Expose repository chart data API

### DIFF
--- a/app/controllers/api/v1/repositories_controller.rb
+++ b/app/controllers/api/v1/repositories_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::RepositoriesController < Api::V1::ApplicationController
-  before_action :find_host, only: [:index, :show, :ping]
+  before_action :find_host, only: [:index, :show, :ping, :chart_data]
   skip_before_action :set_cache_headers, only: [:lookup, :ping]
   skip_before_action :set_api_cache_headers, only: [:lookup, :ping]
 
@@ -55,5 +55,69 @@ class Api::V1::RepositoriesController < Api::V1::ApplicationController
       @host.sync_repository_async(params[:id], request.remote_ip, priority)
     end
     render json: { message: 'pong' }
+  end
+
+  def chart_data
+    @repository = @host.repositories.find_by!('lower(full_name) = ?', params[:id].downcase)
+    period = (params[:period].presence || 'month').to_sym
+
+    scope = @repository.issues
+    scope = scope.created_after(params[:start_date]) if params[:start_date].present?
+    scope = scope.created_before(params[:end_date]) if params[:end_date].present?
+
+    hidden_users = hidden_users_for(@repository)
+    scope = scope.where.not(user: hidden_users) if hidden_users.any?
+
+    if params[:exclude_bots] == 'true'
+      scope = scope.human
+    end
+
+    if params[:only_bots] == 'true'
+      scope = scope.bot
+    end
+
+    data = case params[:chart]
+           when 'issues_opened'
+             scope.issue.group_by_period(period, :created_at).count
+           when 'issues_closed'
+             scope.issue.closed.group_by_period(period, :closed_at).count
+           when 'issue_authors'
+             scope.issue.group_by_period(period, :created_at).distinct.count(:user)
+           when 'issue_average_time_to_close'
+             days(scope.issue.closed.group_by_period(period, :closed_at).average(:time_to_close))
+           when 'pull_requests_opened'
+             scope.pull_request.group_by_period(period, :created_at).count
+           when 'pull_requests_closed'
+             scope.pull_request.closed.group_by_period(period, :closed_at).count
+           when 'pull_requests_merged'
+             scope.pull_request.merged.group_by_period(period, :merged_at).count
+           when 'pull_requests_not_merged'
+             scope.pull_request.not_merged.group_by_period(period, :closed_at).count
+           when 'pull_request_authors'
+             scope.pull_request.group_by_period(period, :created_at).distinct.count(:user)
+           when 'pull_request_average_time_to_close'
+             days(scope.pull_request.closed.group_by_period(period, :closed_at).average(:time_to_close))
+           when 'pull_request_average_time_to_merge'
+             days(scope.pull_request.merged.group_by_period(period, :merged_at).average(:time_to_close))
+           else
+             render json: { error: 'unknown chart' }, status: :bad_request
+             return
+           end
+
+    fresh_when @repository, public: true
+    render json: data
+  end
+
+  private
+
+  def days(data)
+    data.transform_values { |value| value.to_f.seconds.in_days.to_i }
+  end
+
+  def hidden_users_for(repository)
+    Owner.hidden
+         .where(host_id: @host.id)
+         .where(login: repository.issues.select(:user).distinct)
+         .pluck(:login)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
           resources :issues, constraints: { id: /.*/ }, only: [:index, :show]
           member do
             get 'ping', to: 'repositories#ping'
+            get 'chart_data', to: 'repositories#chart_data'
             get 'labels', to: 'issues#labels'
           end
         end

--- a/test/controllers/api/v1/repositories_chart_data_test.rb
+++ b/test/controllers/api/v1/repositories_chart_data_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+
+class Api::V1::RepositoriesChartDataTest < ActionDispatch::IntegrationTest
+  setup do
+    @host = create_or_find_github_host
+    @repository = create_repository(@host, full_name: 'charts/repo', owner: 'charts')
+  end
+
+  test 'returns chart data for issues opened' do
+    create_issue(@repository, number: 1, created_at: Date.new(2026, 1, 10), user: 'alice')
+    create_issue(@repository, number: 2, created_at: Date.new(2026, 1, 20), user: 'bob')
+    create_issue(@repository, number: 3, created_at: Date.new(2026, 2, 1), user: 'alice')
+
+    get chart_data_api_v1_host_repository_path(@host, @repository.full_name), params: {
+      chart: 'issues_opened', period: 'month', start_date: '2026-01-01', end_date: '2026-02-28'
+    }
+
+    assert_response :success
+    data = JSON.parse(response.body)
+    assert_equal 2, data['2026-01-01']
+    assert_equal 1, data['2026-02-01']
+  end
+
+  test 'returns unique issue author chart data and hides configured users' do
+    hidden_user = 'secret_user'
+    Owner.create!(host: @host, login: hidden_user, hidden: true)
+    create_issue(@repository, number: 1, created_at: Date.new(2026, 1, 10), user: 'alice')
+    create_issue(@repository, number: 2, created_at: Date.new(2026, 1, 20), user: hidden_user)
+
+    get chart_data_api_v1_host_repository_path(@host, @repository.full_name), params: {
+      chart: 'issue_authors', period: 'month', start_date: '2026-01-01', end_date: '2026-01-31'
+    }
+
+    assert_response :success
+    data = JSON.parse(response.body)
+    assert_equal 1, data['2026-01-01']
+  end
+
+  test 'returns average pull request merge time in days' do
+    create_pull_request(
+      @repository,
+      number: 1,
+      state: 'closed',
+      created_at: Date.new(2026, 1, 2),
+      closed_at: Date.new(2026, 1, 4),
+      merged_at: Date.new(2026, 1, 4),
+      time_to_close: 3.days.to_i
+    )
+
+    get chart_data_api_v1_host_repository_path(@host, @repository.full_name), params: {
+      chart: 'pull_request_average_time_to_merge', period: 'month', start_date: '2026-01-01', end_date: '2026-01-31'
+    }
+
+    assert_response :success
+    data = JSON.parse(response.body)
+    assert_equal 3, data.values.compact.first
+  end
+
+  test 'returns bad request for unknown chart' do
+    get chart_data_api_v1_host_repository_path(@host, @repository.full_name), params: { chart: 'unknown' }
+
+    assert_response :bad_request
+    assert_equal 'unknown chart', JSON.parse(response.body)['error']
+  end
+end


### PR DESCRIPTION
Fixes #194

## Summary
- Adds a JSON API endpoint for repository chart data at `/api/v1/hosts/:host_id/repositories/:id/chart_data`.
- Supports the same chart types used by the repository charts view: issue/PR opened/closed counts, unique authors, merge/not-merge counts, and average close/merge times in days.
- Applies date, bot, and hidden-user filters before aggregating chart data.
- Returns a 400 JSON error for unknown chart names.

## Validation
- `/opt/homebrew/opt/ruby/bin/bundle exec ruby -c app/controllers/api/v1/repositories_controller.rb`
- `/opt/homebrew/opt/ruby/bin/bundle exec ruby -c test/controllers/api/v1/repositories_chart_data_test.rb`
- `git diff --check`
- `/opt/homebrew/opt/ruby/bin/bundle exec rails test test/controllers/api/v1/repositories_chart_data_test.rb` → 4 runs, 9 assertions, 0 failures, 0 errors, 0 skips