### PR TITLE
Add Bitbucket pull request host support

### DIFF
--- a/app/models/hosts/bitbucket.rb
+++ b/app/models/hosts/bitbucket.rb
@@ -1,0 +1,72 @@
+module Hosts
+  class Bitbucket < Base
+    IGNORABLE_EXCEPTIONS = [Faraday::ResourceNotFound, Faraday::ForbiddenError, Faraday::UnauthorizedError]
+
+    def self.api_missing_error_class
+      Faraday::ResourceNotFound
+    end
+
+    def icon
+      'bitbucket'
+    end
+
+    def issue_url(repository, issue)
+      "#{repository.host.url}/#{repository.full_name}/pull-requests/#{issue.number}"
+    end
+
+    def issues_url(repository)
+      "#{url(repository)}/pull-requests"
+    end
+
+    def load_issues(repository)
+      options = { state: 'ALL', pagelen: 100, sort: '-updated_on' }
+      options[:q] = %(updated_on >= "#{repository.last_synced_at.iso8601}") if repository.last_synced_at.present?
+
+      each_page("/2.0/repositories/#{repository.full_name}/pullrequests", options) do |pull_requests|
+        yield pull_requests.map { |pull_request| map_pull_request(pull_request) }
+      end
+    rescue *IGNORABLE_EXCEPTIONS
+      # Bitbucket issues are not public for many repositories; PR import is best-effort.
+    end
+
+    def map_pull_request(pull_request)
+      {
+        uuid: pull_request['id'],
+        number: pull_request['id'],
+        title: pull_request['title'],
+        state: pull_request['state'].to_s.downcase,
+        locked: false,
+        comments_count: pull_request['comment_count'],
+        created_at: pull_request['created_on'],
+        updated_at: pull_request['updated_on'],
+        closed_at: pull_request['state'] == 'OPEN' ? nil : pull_request['updated_on'],
+        user: pull_request.dig('author', 'nickname') || pull_request.dig('author', 'display_name'),
+        labels: [],
+        assignees: Array(pull_request['reviewers']).map { |reviewer| reviewer['nickname'] || reviewer['display_name'] }.compact,
+        pull_request: true,
+        merged_at: pull_request['state'] == 'MERGED' ? pull_request['updated_on'] : nil
+      }
+    end
+
+    def api_client
+      Faraday.new('https://api.bitbucket.org', request: { timeout: 30 }) do |conn|
+        token = REDIS.get("bitbucket_token:#{@host.id}")
+        conn.request :authorization, :bearer, token if token.present?
+        conn.response :json
+        conn.response :raise_error
+      end
+    end
+
+    def each_page(path, options = {})
+      response = api_client.get(path, options)
+
+      while response.success?
+        yield Array(response.body['values'])
+        next_url = response.body['next']
+        break if next_url.blank?
+
+        response = api_client.get(next_url)
+      end
+    end
+  end
+end

--- a/test/models/hosts_bitbucket_test.rb
+++ b/test/models/hosts_bitbucket_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class HostsBitbucketTest < ActiveSupport::TestCase
+  setup do
+    @host = Host.new(name: 'Bitbucket', url: 'https://bitbucket.org', kind: 'bitbucket')
+    @repository = Repository.new(host: @host, full_name: 'workspace/project')
+    @bitbucket = Hosts::Bitbucket.new(@host)
+  end
+
+  test 'issue_url points at bitbucket pull request page' do
+    issue = Issue.new(number: 12, pull_request: true)
+
+    assert_equal 'https://bitbucket.org/workspace/project/pull-requests/12', @bitbucket.issue_url(@repository, issue)
+  end
+
+  test 'map_pull_request maps bitbucket pull request payload to issue attributes' do
+    payload = {
+      'id' => 12,
+      'title' => 'Add feature',
+      'state' => 'MERGED',
+      'comment_count' => 3,
+      'created_on' => '2026-04-28T10:00:00Z',
+      'updated_on' => '2026-04-29T10:00:00Z',
+      'author' => { 'nickname' => 'alice' },
+      'reviewers' => [{ 'nickname' => 'bob' }, { 'display_name' => 'Carol' }]
+    }
+
+    mapped = @bitbucket.map_pull_request(payload)
+
+    assert_equal 12, mapped[:uuid]
+    assert_equal 12, mapped[:number]
+    assert_equal 'Add feature', mapped[:title]
+    assert_equal 'merged', mapped[:state]
+    assert_equal 3, mapped[:comments_count]
+    assert_equal 'alice', mapped[:user]
+    assert_equal ['bob', 'Carol'], mapped[:assignees]
+    assert mapped[:pull_request]
+    assert_equal '2026-04-29T10:00:00Z', mapped[:merged_at]
+  end
+end


### PR DESCRIPTION
Refs #7

## Summary

- Adds a Bitbucket host adapter focused on public pull request import.
- Maps Bitbucket pull request payloads into the existing issue/pull_request attributes used by the service.
- Adds Bitbucket PR URLs, pagination, optional bearer-token support, and model coverage.

## Validation

- `ruby -c app/models/hosts/bitbucket.rb`
- `ruby -c test/models/hosts_bitbucket_test.rb`
- `git diff --check`

`bundle exec ruby -Itest test/models/hosts_bitbucket_test.rb` is blocked locally because this checkout requires Bundler 4.0.10 from `Gemfile.lock`, which is not available in the system Ruby environment.