### PR TITLE
Rename /hosts operationId to getHosts

### DIFF
--- a/openapi/api/v1/openapi.yaml
+++ b/openapi/api/v1/openapi.yaml
@@ -36,8 +36,8 @@ paths:
                 $ref: '#/components/schemas/Repository'
   /hosts:
     get:
-      summary: list registies
-      operationId: getRegistries
+      summary: list hosts
+      operationId: getHosts
       parameters:
         - name: page
           in: query


### PR DESCRIPTION
The `/hosts` endpoint had `operationId: getRegistries` and summary `list registies`, copy-pasted from the packages spec. Renamed to `getHosts` / `list hosts` to match the path and the singular `getHost`.

This changes generated client method names for spec consumers (`GetRegistries` → `GetHosts`).