### PR TITLE
Fix job creation issue sync scheduling

### DIFF
--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::JobsController < Api::V1::ApplicationController
   def create
     @job = Job.new(url: params[:url], status: 'pending', ip: request.remote_ip)
     if @job.save
-      @job.parse_issues_async
+      @job.sync_issues_async
       redirect_to api_v1_job_path(@job)
     else
       error = {

--- a/test/controllers/api/v1/jobs_controller_test.rb
+++ b/test/controllers/api/v1/jobs_controller_test.rb
@@ -5,7 +5,7 @@ class Api::V1::JobsControllerTest < ActionDispatch::IntegrationTest
     url = 'https://github.com/rails/rails'
     
     # Mock the async job
-    Job.any_instance.expects(:parse_issues_async).once
+    Job.any_instance.expects(:sync_issues_async).once
     
     assert_difference 'Job.count', 1 do
       post api_v1_jobs_path, params: { url: url }, as: :json
@@ -36,7 +36,7 @@ class Api::V1::JobsControllerTest < ActionDispatch::IntegrationTest
 
   test 'create job records IP address' do
     url = 'https://github.com/rails/rails'
-    Job.any_instance.expects(:parse_issues_async).once
+    Job.any_instance.expects(:sync_issues_async).once
     
     post api_v1_jobs_path, params: { url: url }, as: :json, headers: { 'REMOTE_ADDR' => '1.2.3.4' }
     


### PR DESCRIPTION
Calls the existing `Job#sync_issues_async` method when `POST /api/v1/jobs` creates a job. Updates the controller coverage to assert the method call.

Closes #840