### PR TITLE
Keep synced repositories visible

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -174,9 +174,6 @@ class Repository < ApplicationRecord
 
     issues.reset
     update_issue_counts
-    self.status = 'active'
-    self.last_synced_at = Time.now
-    self.save
   rescue => e
     self.status = 'error'
     self.last_synced_at = Time.now

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -1,6 +1,34 @@
 require 'test_helper'
 
 class RepositoryTest < ActiveSupport::TestCase
+  test "successful issue sync leaves repository active and visible" do
+    host = create(:host)
+    repository = create(:repository, host: host, status: 'error', last_synced_at: nil)
+    issue_data = {
+      uuid: SecureRandom.uuid,
+      number: 1,
+      state: 'open',
+      title: 'Test Issue',
+      user: 'testuser',
+      labels: [],
+      assignees: [],
+      locked: false,
+      comments_count: 0,
+      pull_request: false,
+      created_at: 1.day.ago,
+      updated_at: Time.current
+    }
+    host_api = mock
+    host_api.expects(:load_issues).with(repository).yields([issue_data])
+    host.expects(:host_instance).returns(host_api)
+
+    repository.sync_issues
+
+    repository.reload
+    assert_nil repository.status
+    assert_includes Repository.visible, repository
+  end
+
   test "sync_issues should upsert issues without duplicates" do
     host = create(:host)
     repository = create(:repository, host: host)


### PR DESCRIPTION
Successful issue syncs now keep the existing `nil` active status instead of overwriting it with `"active"`, so synced repositories remain in visible listings. Adds regression coverage for clearing an error status and remaining visible.

Existing `"active"` rows should be repaired in batches after deployment.

Closes #841