### PR TITLE
Fix stale maintainer attribution

### DIFF
--- a/app/controllers/api/v1/repositories_controller.rb
+++ b/app/controllers/api/v1/repositories_controller.rb
@@ -41,6 +41,7 @@ class Api::V1::RepositoriesController < Api::V1::ApplicationController
 
   def show
     @repository = @host.repositories.find_by!('lower(full_name) = ?', params[:id].downcase)
+    @repository.reconcile_async(request.remote_ip)
     fresh_when @repository, public: true
     @maintainers = @repository.issues.maintainers.group(:user).count.sort_by{|k,v| -v }
     @active_maintainers = @repository.issues.maintainers.where('issues.created_at > ?', 1.year.ago).group(:user).count.sort_by{|k,v| -v }

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -41,6 +41,8 @@ class RepositoriesController < ApplicationController
     owner = Owner.find_by(host: @host, login: @repository.owner)
     raise ActiveRecord::RecordNotFound if owner&.hidden?
 
+    @repository.reconcile_async(request.remote_ip)
+
     @hidden_users = hidden_users_for(@repository)
 
     @maintainers = @repository.issues.maintainers.group(:user).count

--- a/app/models/hosts/github.rb
+++ b/app/models/hosts/github.rb
@@ -64,26 +64,19 @@ module Hosts
       html_url(repository) + "/#{issue.pull_request ? 'pull' : 'issues'}/#{issue.number}"
     end
 
-    def load_issues(repository)
-      if repository.last_synced_at.present?
+    def load_issues(repository, full: false)
+      if repository.last_synced_at.present? && !full
         url = "#{api_client.api_endpoint}repos/#{repository.full_name}/issues?state=all&sort=updated&direction=desc&per_page=100&since=#{repository.last_synced_at}"
       else
         url = "#{api_client.api_endpoint}repos/#{repository.full_name}/issues?state=all&sort=created_at&direction=asc&per_page=100"
       end
 
       response = api_client.agent.call(:get, url, nil, {})
-      
-      mapped_issues = map_issues(response.data)
 
-      yield(mapped_issues)
-
-      while response && response.rels[:next]
-        response = response.rels[:next].get
-        
-        map_issues(response.data)
-
-        yield(mapped_issues)
-      end 
+      while response
+        yield(map_issues(response.data))
+        response = response.rels[:next]&.get
+      end
     end
 
     def map_issues(data)

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -92,7 +92,7 @@ class Job < ApplicationRecord
     end
 
     unless response.success?
-      existing_repo&.clear_reconciliation if full
+      existing_repo&.reconciliation&.clear if full
       return nil
     end
     json = response.body
@@ -110,7 +110,8 @@ class Job < ApplicationRecord
     results = repo.as_json
     return results
   rescue
-    (repo || existing_repo)&.clear_reconciliation if full
+    reconciled_repository = repo || existing_repo
+    reconciled_repository&.reconciliation&.clear if full
     raise
   end
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -30,25 +30,34 @@ class Job < ApplicationRecord
     ['complete', 'error'].include?(status)
   end
 
-  def sync_issues_async(priority = false)
+  def sync_issues_async(priority = false, full: false)
     if priority
-      sidekiq_id = SyncIssuesWorker.perform_with_priority(id, priority)
+      sidekiq_id = if full
+        SyncIssuesWorker.perform_with_priority(id, priority, true)
+      else
+        SyncIssuesWorker.perform_with_priority(id, priority)
+      end
+    elsif full
+      sidekiq_id = SyncIssuesWorker.perform_async(id, true)
     else
       sidekiq_id = SyncIssuesWorker.perform_async(id)
     end
     update(sidekiq_id: sidekiq_id)
   end
 
-  def perform_issue_syncing
+  def perform_issue_syncing(full = false)
     begin
-      results = sync_issues
+      results = full ? sync_issues(full: true) : sync_issues
       update!(results: results, status: 'complete')      
     rescue => e
       update(results: {error: e.inspect}, status: 'error')
     end
   end
 
-  def sync_issues
+  def sync_issues(full: false)
+    existing_repo = nil
+    repo = nil
+
     # Check if repository already marked as not_found
     parsed_url = Addressable::URI.parse(url)
     domain = parsed_url.host
@@ -61,6 +70,11 @@ class Job < ApplicationRecord
       if existing_repo&.status == 'not_found'
         raise "Repository #{full_name} is marked as not_found"
       end
+    end
+
+    if full && existing_repo
+      existing_repo.reconcile
+      return existing_repo.as_json
     end
 
     # TODO don't depend on the repos service being up
@@ -77,16 +91,26 @@ class Job < ApplicationRecord
       raise "Repository not found in repos service: #{url}"
     end
 
-    return nil unless response.success?
+    unless response.success?
+      existing_repo&.clear_reconciliation if full
+      return nil
+    end
     json = response.body
 
     host = Host.find_by(name: json['host']['name'])
     repo = host.repositories.find_by('lower(full_name) = ?', json['full_name'].downcase)
     repo = host.repositories.create(full_name: json['full_name']) if repo.nil?
 
-    repo.sync_issues
+    if full
+      repo.reconcile
+    else
+      repo.sync_issues
+    end
 
     results = repo.as_json
     return results
+  rescue
+    (repo || existing_repo)&.clear_reconciliation if full
+    raise
   end
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,29 +1,4 @@
-require 'digest'
-
 class Repository < ApplicationRecord
-  RECONCILIATION_ADMISSION_SCRIPT = <<~LUA.freeze
-    redis.call('ZREMRANGEBYSCORE', KEYS[2], '-inf', ARGV[1])
-
-    if redis.call('EXISTS', KEYS[1]) == 1 then
-      return 0
-    end
-
-    if redis.call('EXISTS', KEYS[3]) == 1 then
-      return 0
-    end
-
-    if redis.call('ZCARD', KEYS[2]) >= tonumber(ARGV[3]) then
-      return 0
-    end
-
-    redis.call('SET', KEYS[1], 'pending', 'EX', ARGV[2])
-    redis.call('SET', KEYS[3], ARGV[4], 'EX', ARGV[5])
-    redis.call('ZADD', KEYS[2], tonumber(ARGV[1]) + tonumber(ARGV[2]), ARGV[4])
-    redis.call('EXPIRE', KEYS[2], ARGV[2])
-
-    return 1
-  LUA
-
   def self.sortable_columns
     {
       'last_synced_at' => 'last_synced_at',
@@ -90,89 +65,19 @@ class Repository < ApplicationRecord
   end
 
   def reconcile_async(remote_ip = '0.0.0.0', priority = false)
-    return unless github?
-    return if last_synced_at.blank?
-    return unless acquire_reconciliation_slot(remote_ip)
-
-    job = Job.new(url: html_url, status: 'pending', ip: remote_ip)
-    unless job.save
-      clear_reconciliation
-      return
-    end
-
-    job.sync_issues_async(priority, full: true)
-    job
-  rescue => e
-    begin
-      clear_reconciliation
-    rescue => redis_error
-      Rails.logger.error "Failed to clear reconciliation throttle for #{full_name}: #{redis_error.message}"
-    end
-    Rails.logger.error "Failed to enqueue reconciliation for #{full_name}: #{e.message}"
-    nil
+    reconciliation.enqueue(remote_ip, priority)
   end
 
   def reconcile
-    raise ArgumentError, 'Full reconciliation is only supported for GitHub repositories' unless github?
+    reconciliation.perform
+  end
 
-    sync_issues(full: true)
+  def reconciliation
+    Repository::Reconciliation.new(self)
   end
 
   def github?
     host.kind.casecmp?('github')
-  end
-
-  def reconciliation_key
-    "issues:{github-reconciliations}:repository:#{id}"
-  end
-
-  def reconciliation_pending_key
-    'issues:{github-reconciliations}:pending'
-  end
-
-  def reconciliation_source_key(remote_ip)
-    digest = Digest::SHA256.hexdigest(remote_ip.to_s)
-    "issues:{github-reconciliations}:source:#{digest}"
-  end
-
-  def reconciliation_pending_ttl
-    1.day.to_i
-  end
-
-  def reconciliation_pending_limit
-    ENV.fetch('GITHUB_RECONCILIATION_PENDING_LIMIT', '20').to_i.clamp(1, 100)
-  end
-
-  def reconciliation_source_interval
-    ENV.fetch('GITHUB_RECONCILIATION_SOURCE_INTERVAL_SECONDS', '300').to_i.clamp(1, 1.day.to_i)
-  end
-
-  def reconciliation_interval
-    ENV.fetch('GITHUB_RECONCILIATION_INTERVAL_DAYS', '30').to_i.clamp(1, 365).days.to_i
-  end
-
-  def acquire_reconciliation_slot(remote_ip)
-    now = Time.current.to_i
-    result = REDIS.eval(
-      RECONCILIATION_ADMISSION_SCRIPT,
-      keys: [reconciliation_key, reconciliation_pending_key, reconciliation_source_key(remote_ip)],
-      argv: [now, reconciliation_pending_ttl, reconciliation_pending_limit, id, reconciliation_source_interval]
-    )
-    result == 1
-  end
-
-  def mark_reconciled
-    REDIS.set(reconciliation_key, Time.current.iso8601, ex: reconciliation_interval)
-    release_reconciliation_slot
-  end
-
-  def clear_reconciliation
-    REDIS.del(reconciliation_key)
-    release_reconciliation_slot
-  end
-
-  def release_reconciliation_slot
-    REDIS.zrem(reconciliation_pending_key, id)
   end
 
   def sync_details
@@ -293,9 +198,9 @@ class Repository < ApplicationRecord
 
     issues.reset
     update_issue_counts
-    mark_reconciled if full_reconciliation
+    reconciliation.complete if full_reconciliation
   rescue => e
-    clear_reconciliation if full_reconciliation
+    reconciliation.clear if full_reconciliation
     self.status = 'error'
     self.last_synced_at = Time.now
     self.save

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,4 +1,29 @@
+require 'digest'
+
 class Repository < ApplicationRecord
+  RECONCILIATION_ADMISSION_SCRIPT = <<~LUA.freeze
+    redis.call('ZREMRANGEBYSCORE', KEYS[2], '-inf', ARGV[1])
+
+    if redis.call('EXISTS', KEYS[1]) == 1 then
+      return 0
+    end
+
+    if redis.call('EXISTS', KEYS[3]) == 1 then
+      return 0
+    end
+
+    if redis.call('ZCARD', KEYS[2]) >= tonumber(ARGV[3]) then
+      return 0
+    end
+
+    redis.call('SET', KEYS[1], 'pending', 'EX', ARGV[2])
+    redis.call('SET', KEYS[3], ARGV[4], 'EX', ARGV[5])
+    redis.call('ZADD', KEYS[2], tonumber(ARGV[1]) + tonumber(ARGV[2]), ARGV[4])
+    redis.call('EXPIRE', KEYS[2], ARGV[2])
+
+    return 1
+  LUA
+
   def self.sortable_columns
     {
       'last_synced_at' => 'last_synced_at',
@@ -67,7 +92,7 @@ class Repository < ApplicationRecord
   def reconcile_async(remote_ip = '0.0.0.0', priority = false)
     return unless github?
     return if last_synced_at.blank?
-    return unless REDIS.set(reconciliation_key, 'pending', nx: true, ex: reconciliation_pending_ttl)
+    return unless acquire_reconciliation_slot(remote_ip)
 
     job = Job.new(url: html_url, status: 'pending', ip: remote_ip)
     unless job.save
@@ -98,23 +123,56 @@ class Repository < ApplicationRecord
   end
 
   def reconciliation_key
-    "issues:repository:#{id}:reconciled"
+    "issues:{github-reconciliations}:repository:#{id}"
+  end
+
+  def reconciliation_pending_key
+    'issues:{github-reconciliations}:pending'
+  end
+
+  def reconciliation_source_key(remote_ip)
+    digest = Digest::SHA256.hexdigest(remote_ip.to_s)
+    "issues:{github-reconciliations}:source:#{digest}"
   end
 
   def reconciliation_pending_ttl
     1.day.to_i
   end
 
+  def reconciliation_pending_limit
+    ENV.fetch('GITHUB_RECONCILIATION_PENDING_LIMIT', '20').to_i.clamp(1, 100)
+  end
+
+  def reconciliation_source_interval
+    ENV.fetch('GITHUB_RECONCILIATION_SOURCE_INTERVAL_SECONDS', '300').to_i.clamp(1, 1.day.to_i)
+  end
+
   def reconciliation_interval
     ENV.fetch('GITHUB_RECONCILIATION_INTERVAL_DAYS', '30').to_i.clamp(1, 365).days.to_i
   end
 
+  def acquire_reconciliation_slot(remote_ip)
+    now = Time.current.to_i
+    result = REDIS.eval(
+      RECONCILIATION_ADMISSION_SCRIPT,
+      keys: [reconciliation_key, reconciliation_pending_key, reconciliation_source_key(remote_ip)],
+      argv: [now, reconciliation_pending_ttl, reconciliation_pending_limit, id, reconciliation_source_interval]
+    )
+    result == 1
+  end
+
   def mark_reconciled
     REDIS.set(reconciliation_key, Time.current.iso8601, ex: reconciliation_interval)
+    release_reconciliation_slot
   end
 
   def clear_reconciliation
     REDIS.del(reconciliation_key)
+    release_reconciliation_slot
+  end
+
+  def release_reconciliation_slot
+    REDIS.zrem(reconciliation_pending_key, id)
   end
 
   def sync_details

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -64,6 +64,59 @@ class Repository < ApplicationRecord
     end
   end
 
+  def reconcile_async(remote_ip = '0.0.0.0', priority = false)
+    return unless github?
+    return if last_synced_at.blank?
+    return unless REDIS.set(reconciliation_key, 'pending', nx: true, ex: reconciliation_pending_ttl)
+
+    job = Job.new(url: html_url, status: 'pending', ip: remote_ip)
+    unless job.save
+      clear_reconciliation
+      return
+    end
+
+    job.sync_issues_async(priority, full: true)
+    job
+  rescue => e
+    begin
+      clear_reconciliation
+    rescue => redis_error
+      Rails.logger.error "Failed to clear reconciliation throttle for #{full_name}: #{redis_error.message}"
+    end
+    Rails.logger.error "Failed to enqueue reconciliation for #{full_name}: #{e.message}"
+    nil
+  end
+
+  def reconcile
+    raise ArgumentError, 'Full reconciliation is only supported for GitHub repositories' unless github?
+
+    sync_issues(full: true)
+  end
+
+  def github?
+    host.kind.casecmp?('github')
+  end
+
+  def reconciliation_key
+    "issues:repository:#{id}:reconciled"
+  end
+
+  def reconciliation_pending_ttl
+    1.day.to_i
+  end
+
+  def reconciliation_interval
+    ENV.fetch('GITHUB_RECONCILIATION_INTERVAL_DAYS', '30').to_i.clamp(1, 365).days.to_i
+  end
+
+  def mark_reconciled
+    REDIS.set(reconciliation_key, Time.current.iso8601, ex: reconciliation_interval)
+  end
+
+  def clear_reconciliation
+    REDIS.del(reconciliation_key)
+  end
+
   def sync_details
     conn = EcosystemsApiClient.client(repos_api_url)
     response = conn.get
@@ -141,9 +194,10 @@ class Repository < ApplicationRecord
     issues.where(pull_request: true).past_year.group(:user).count.sort_by{|k,v| -v }
   end
 
-  def sync_issues
-    host.host_instance.load_issues(self) do |data|
-      return if data.empty?
+  def sync_issues(full: false)
+    full_reconciliation = full || (github? && last_synced_at.blank?)
+    process_page = proc do |data|
+      next if data.empty?
       
       issues_data = data.map do |issue|
         time_to_close = if issue[:closed_at].present? && issue[:created_at].present?
@@ -172,9 +226,18 @@ class Repository < ApplicationRecord
       )
     end
 
+    host_loader = host.host_instance
+    if full
+      host_loader.load_issues(self, full: true, &process_page)
+    else
+      host_loader.load_issues(self, &process_page)
+    end
+
     issues.reset
     update_issue_counts
+    mark_reconciled if full_reconciliation
   rescue => e
+    clear_reconciliation if full_reconciliation
     self.status = 'error'
     self.last_synced_at = Time.now
     self.save

--- a/app/models/repository/reconciliation.rb
+++ b/app/models/repository/reconciliation.rb
@@ -1,0 +1,116 @@
+require 'digest'
+
+class Repository::Reconciliation
+  ADMISSION_SCRIPT = <<~LUA.freeze
+    redis.call('ZREMRANGEBYSCORE', KEYS[2], '-inf', ARGV[1])
+
+    if redis.call('EXISTS', KEYS[1]) == 1 then
+      return 0
+    end
+
+    if redis.call('EXISTS', KEYS[3]) == 1 then
+      return 0
+    end
+
+    if redis.call('ZCARD', KEYS[2]) >= tonumber(ARGV[3]) then
+      return 0
+    end
+
+    redis.call('SET', KEYS[1], 'pending', 'EX', ARGV[2])
+    redis.call('SET', KEYS[3], ARGV[4], 'EX', ARGV[5])
+    redis.call('ZADD', KEYS[2], tonumber(ARGV[1]) + tonumber(ARGV[2]), ARGV[4])
+    redis.call('EXPIRE', KEYS[2], ARGV[2])
+
+    return 1
+  LUA
+
+  attr_reader :repository
+
+  def initialize(repository)
+    @repository = repository
+  end
+
+  def enqueue(remote_ip = '0.0.0.0', priority = false)
+    return unless repository.github?
+    return if repository.last_synced_at.blank?
+    return unless acquire_slot(remote_ip)
+
+    job = Job.new(url: repository.html_url, status: 'pending', ip: remote_ip)
+    unless job.save
+      clear
+      return
+    end
+
+    job.sync_issues_async(priority, full: true)
+    job
+  rescue => e
+    begin
+      clear
+    rescue => redis_error
+      Rails.logger.error "Failed to clear reconciliation throttle for #{repository.full_name}: #{redis_error.message}"
+    end
+    Rails.logger.error "Failed to enqueue reconciliation for #{repository.full_name}: #{e.message}"
+    nil
+  end
+
+  def perform
+    unless repository.github?
+      raise ArgumentError, 'Full reconciliation is only supported for GitHub repositories'
+    end
+
+    repository.sync_issues(full: true)
+  end
+
+  def key
+    "issues:{github-reconciliations}:repository:#{repository.id}"
+  end
+
+  def pending_key
+    'issues:{github-reconciliations}:pending'
+  end
+
+  def source_key(remote_ip)
+    digest = Digest::SHA256.hexdigest(remote_ip.to_s)
+    "issues:{github-reconciliations}:source:#{digest}"
+  end
+
+  def pending_ttl
+    1.day.to_i
+  end
+
+  def pending_limit
+    ENV.fetch('GITHUB_RECONCILIATION_PENDING_LIMIT', '20').to_i.clamp(1, 100)
+  end
+
+  def source_interval
+    ENV.fetch('GITHUB_RECONCILIATION_SOURCE_INTERVAL_SECONDS', '300').to_i.clamp(1, 1.day.to_i)
+  end
+
+  def interval
+    ENV.fetch('GITHUB_RECONCILIATION_INTERVAL_DAYS', '30').to_i.clamp(1, 365).days.to_i
+  end
+
+  def acquire_slot(remote_ip)
+    now = Time.current.to_i
+    result = REDIS.eval(
+      ADMISSION_SCRIPT,
+      keys: [key, pending_key, source_key(remote_ip)],
+      argv: [now, pending_ttl, pending_limit, repository.id, source_interval]
+    )
+    result == 1
+  end
+
+  def complete
+    REDIS.set(key, Time.current.iso8601, ex: interval)
+    release_slot
+  end
+
+  def clear
+    REDIS.del(key)
+    release_slot
+  end
+
+  def release_slot
+    REDIS.zrem(pending_key, repository.id)
+  end
+end

--- a/app/sidekiq/sync_issues_worker.rb
+++ b/app/sidekiq/sync_issues_worker.rb
@@ -4,15 +4,17 @@ class SyncIssuesWorker
   
   sidekiq_options queue: :default, lock: :until_executed, lock_expiration: 1.day.to_i
 
-  def perform(job_id)
-    Job.find_by_id!(job_id).perform_issue_syncing
+  def perform(job_id, full = false)
+    Job.find_by_id!(job_id).perform_issue_syncing(full)
   end
   
   # Enqueue job to specific queue based on priority
-  def self.perform_with_priority(job_id, priority = false)
+  def self.perform_with_priority(job_id, priority = false, full = false)
     queue = priority ? :high_priority : :default
-    
-    result = client_push('class' => self, 'args' => [job_id], 'queue' => queue)
+
+    args = [job_id]
+    args << true if full
+    result = client_push('class' => self, 'args' => args, 'queue' => queue)
     result['jid'] # Return the Sidekiq job ID
   end
 end

--- a/lib/tasks/issues.rake
+++ b/lib/tasks/issues.rake
@@ -1,0 +1,14 @@
+namespace :issues do
+  desc 'Fully reconcile a GitHub repository from the issues API'
+  task :reconcile, [:host_name, :full_name] => :environment do |_task, args|
+    unless args[:host_name].present? && args[:full_name].present?
+      abort 'Usage: bin/rails issues:reconcile[GitHub,owner/repository]'
+    end
+
+    host = Host.find_by_name!(args[:host_name])
+    repository = host.repositories.find_by!('lower(full_name) = ?', args[:full_name].downcase)
+    repository.reconcile
+
+    puts "Reconciled #{repository.full_name}: #{repository.issues_count} issues, #{repository.pull_requests_count} pull requests"
+  end
+end

--- a/test/controllers/api/v1/repositories_controller_test.rb
+++ b/test/controllers/api/v1/repositories_controller_test.rb
@@ -6,6 +6,7 @@ class Api::V1::RepositoriesControllerTest < ActionDispatch::IntegrationTest
     @repository = create_or_find_rails_repository(@host)
     # Update last_synced_at to force sync
     @repository.update!(last_synced_at: 2.days.ago)
+    Repository.any_instance.stubs(:reconcile_async)
   end
 
   test 'lookup with priority queues to high_priority queue' do
@@ -115,6 +116,8 @@ class Api::V1::RepositoriesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'show returns repository details' do
+    Repository.any_instance.expects(:reconcile_async).with('127.0.0.1').once
+
     get api_v1_host_repository_path(@host, @repository.full_name)
     assert_response :success
     

--- a/test/controllers/repositories_controller_test.rb
+++ b/test/controllers/repositories_controller_test.rb
@@ -5,6 +5,7 @@ class RepositoriesControllerTest < ActionDispatch::IntegrationTest
     @host = create_or_find_github_host
     @repository = create_or_find_rails_repository(@host)
     @user_ip = '127.0.0.1'
+    Repository.any_instance.stubs(:reconcile_async)
   end
 
   test 'should redirect index to host page' do
@@ -13,6 +14,8 @@ class RepositoriesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should show repository' do
+    Repository.any_instance.expects(:reconcile_async).with(@user_ip).once
+
     get host_repository_path(@host, @repository.full_name)
     assert_response :success
     assert_template 'repositories/show'

--- a/test/models/hosts/github_test.rb
+++ b/test/models/hosts/github_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+class Hosts::GithubTest < ActiveSupport::TestCase
+  setup do
+    @host = create_or_find_github_host
+    @repository = create(:repository, host: @host, full_name: 'owner/repository', last_synced_at: Time.zone.parse('2026-08-01 12:00:00 UTC'))
+    @github = Hosts::Github.new(@host)
+  end
+
+  test 'incremental load requests issues updated since the last sync' do
+    response = stub(data: [github_issue(1)], rels: {})
+    expected_url = "https://api.github.com/repos/#{@repository.full_name}/issues?state=all&sort=updated&direction=desc&per_page=100&since=#{@repository.last_synced_at}"
+    stub_api_request(expected_url, response)
+
+    pages = []
+    @github.load_issues(@repository) { |issues| pages << issues }
+
+    assert_equal [[1]], pages.map { |issues| issues.map { |issue| issue[:number] } }
+  end
+
+  test 'full load omits the incremental watermark and yields every page' do
+    second_response = stub(data: [github_issue(2)], rels: {})
+    next_relation = mock
+    next_relation.expects(:get).returns(second_response)
+    first_response = stub(data: [github_issue(1)], rels: { next: next_relation })
+    expected_url = "https://api.github.com/repos/#{@repository.full_name}/issues?state=all&sort=created_at&direction=asc&per_page=100"
+    stub_api_request(expected_url, first_response)
+
+    pages = []
+    @github.load_issues(@repository, full: true) { |issues| pages << issues }
+
+    assert_equal [[1], [2]], pages.map { |issues| issues.map { |issue| issue[:number] } }
+  end
+
+  def github_issue(number)
+    stub(
+      id: number.to_s,
+      node_id: "node-#{number}",
+      number: number,
+      title: "Issue #{number}",
+      state: 'open',
+      locked: false,
+      comments: 0,
+      created_at: 1.day.ago,
+      updated_at: Time.current,
+      closed_at: nil,
+      user: stub(login: 'author'),
+      labels: [],
+      assignees: [],
+      pull_request: nil,
+      author_association: 'NONE',
+      state_reason: nil
+    )
+  end
+
+  def stub_api_request(expected_url, response)
+    agent = mock
+    agent.expects(:call).with(:get, expected_url, nil, {}).returns(response)
+    client = stub(api_endpoint: 'https://api.github.com/', agent: agent)
+    @github.stubs(:api_client).returns(client)
+  end
+end

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -60,6 +60,37 @@ class JobTest < ActiveSupport::TestCase
     assert_nil repo.status
   end
 
+  test "sync_issues reconciles an existing repository without the repos service" do
+    host = create_or_find_github_host
+    repository = create(:repository, host: host, full_name: 'observablehq/notebook-kit')
+    job = create(:job, url: repository.html_url)
+
+    Repository.any_instance.expects(:reconcile).once
+
+    assert_not_nil job.sync_issues(full: true)
+    assert_not_requested :get, /repos\.ecosyste\.ms/
+  end
+
+  test "sync_issues_async includes the full reconciliation worker argument" do
+    job = create(:job)
+    SyncIssuesWorker.expects(:perform_async).with(job.id, true).returns('full-sync-job-id')
+
+    job.sync_issues_async(false, full: true)
+
+    assert_equal 'full-sync-job-id', job.reload.sidekiq_id
+  end
+
+  test "failed full reconciliation clears the repository throttle" do
+    host = create_or_find_github_host
+    repository = create(:repository, host: host, full_name: 'observablehq/notebook-kit')
+    job = create(:job, url: repository.html_url)
+
+    Repository.any_instance.expects(:reconcile).raises(StandardError.new('GitHub unavailable'))
+    Repository.any_instance.expects(:clear_reconciliation).once
+
+    assert_raises(StandardError) { job.sync_issues(full: true) }
+  end
+
   test "sync_issues returns nil for non-404 error responses" do
     job = create(:job, url: 'https://gitlab.com/test-org/test-repo')
 

--- a/test/models/job_test.rb
+++ b/test/models/job_test.rb
@@ -84,9 +84,11 @@ class JobTest < ActiveSupport::TestCase
     host = create_or_find_github_host
     repository = create(:repository, host: host, full_name: 'observablehq/notebook-kit')
     job = create(:job, url: repository.html_url)
+    reconciliation = mock
 
     Repository.any_instance.expects(:reconcile).raises(StandardError.new('GitHub unavailable'))
-    Repository.any_instance.expects(:clear_reconciliation).once
+    Repository.any_instance.expects(:reconciliation).returns(reconciliation)
+    reconciliation.expects(:clear).once
 
     assert_raises(StandardError) { job.sync_issues(full: true) }
   end

--- a/test/models/repository/reconciliation_test.rb
+++ b/test/models/repository/reconciliation_test.rb
@@ -1,0 +1,100 @@
+require 'test_helper'
+
+class Repository::ReconciliationTest < ActiveSupport::TestCase
+  test "enqueue schedules one full sync" do
+    host = create_or_find_github_host
+    repository = create(:repository, host: host)
+    reconciliation = repository.reconciliation
+    job = mock
+
+    reconciliation.expects(:acquire_slot).with('127.0.0.1').returns(true)
+    Job.expects(:new).with(url: repository.html_url, status: 'pending', ip: '127.0.0.1').returns(job)
+    job.expects(:save).returns(true)
+    job.expects(:sync_issues_async).with(false, full: true).returns(true)
+
+    assert_equal job, reconciliation.enqueue('127.0.0.1')
+  end
+
+  test "enqueue does not schedule while reconciliation is pending or fresh" do
+    host = create_or_find_github_host
+    repository = create(:repository, host: host)
+    reconciliation = repository.reconciliation
+
+    reconciliation.expects(:acquire_slot).with('0.0.0.0').returns(false)
+    Job.expects(:new).never
+
+    assert_nil reconciliation.enqueue
+  end
+
+  test "enqueue leaves a new repository to its initial full sync" do
+    host = create_or_find_github_host
+    repository = create(:repository, host: host, last_synced_at: nil)
+    reconciliation = repository.reconciliation
+
+    reconciliation.expects(:acquire_slot).never
+    Job.expects(:new).never
+
+    assert_nil reconciliation.enqueue
+  end
+
+  test "admission rate limits sources and caps pending jobs" do
+    host = create_or_find_github_host
+    repositories = 3.times.map { create(:repository, host: host) }
+    reconciliations = repositories.map(&:reconciliation)
+    key_prefix = "issues:test:#{SecureRandom.hex}"
+    pending_key = "#{key_prefix}:pending"
+    source_keys = {
+      'source-a' => "#{key_prefix}:source:a",
+      'source-b' => "#{key_prefix}:source:b",
+      'source-c' => "#{key_prefix}:source:c",
+    }
+
+    reconciliations.each_with_index do |reconciliation, index|
+      reconciliation.stubs(:key).returns("#{key_prefix}:repository:#{index}")
+      reconciliation.stubs(:pending_key).returns(pending_key)
+      source_keys.each do |source, key|
+        reconciliation.stubs(:source_key).with(source).returns(key)
+      end
+      reconciliation.stubs(:pending_ttl).returns(60)
+      reconciliation.stubs(:pending_limit).returns(2)
+      reconciliation.stubs(:source_interval).returns(60)
+      reconciliation.stubs(:interval).returns(60)
+    end
+
+    REDIS.zadd(pending_key, 1, 'expired-repository')
+
+    assert reconciliations[0].acquire_slot('source-a')
+    assert_nil REDIS.zscore(pending_key, 'expired-repository')
+    assert_not reconciliations[1].acquire_slot('source-a')
+    assert reconciliations[1].acquire_slot('source-b')
+    assert_not reconciliations[2].acquire_slot('source-c')
+    assert_equal 2, REDIS.zcard(pending_key)
+
+    reconciliations[0].complete
+
+    assert reconciliations[2].acquire_slot('source-c')
+    assert_equal 2, REDIS.zcard(pending_key)
+  ensure
+    REDIS.del(
+      pending_key,
+      *source_keys.values,
+      *repositories.each_index.map { |index| "#{key_prefix}:repository:#{index}" }
+    ) if key_prefix
+  end
+
+  test "enqueue clears its throttle when queueing fails" do
+    host = create_or_find_github_host
+    repository = create(:repository, host: host)
+    reconciliation = repository.reconciliation
+    job = mock
+
+    reconciliation.expects(:acquire_slot).returns(true)
+    reconciliation.expects(:clear).once
+    Job.expects(:new).returns(job)
+    job.expects(:save).returns(true)
+    job.expects(:sync_issues_async).raises(StandardError.new('queue unavailable'))
+    Rails.logger.expects(:error).with("Failed to enqueue reconciliation for #{repository.full_name}: queue unavailable")
+
+    assert_nil reconciliation.enqueue
+  end
+end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -21,7 +21,9 @@ class RepositoryTest < ActiveSupport::TestCase
     host_api = mock
     host_api.expects(:load_issues).with(repository).yields([issue_data])
     host.expects(:host_instance).returns(host_api)
-    repository.expects(:mark_reconciled).once
+    reconciliation = repository.reconciliation
+    repository.stubs(:reconciliation).returns(reconciliation)
+    reconciliation.expects(:complete).once
 
     repository.sync_issues
 
@@ -127,7 +129,9 @@ class RepositoryTest < ActiveSupport::TestCase
     host_api = mock
     host_api.expects(:load_issues).with(repository, full: true).yields(issue_data)
     host.expects(:host_instance).returns(host_api)
-    repository.expects(:mark_reconciled).once
+    reconciliation = repository.reconciliation
+    repository.stubs(:reconciliation).returns(reconciliation)
+    reconciliation.expects(:complete).once
 
     repository.reconcile
 
@@ -135,98 +139,6 @@ class RepositoryTest < ActiveSupport::TestCase
     assert_equal [21, 90, 91], repository.issues.where(user: 'mootari').order(:number).pluck(:number)
     assert_equal 3, repository.issues_count
     assert_empty repository.issues.maintainers.where(user: 'mootari')
-  end
-
-  test "reconcile_async enqueues one full sync" do
-    host = create_or_find_github_host
-    repository = create(:repository, host: host)
-    job = mock
-
-    repository.expects(:acquire_reconciliation_slot).with('127.0.0.1').returns(true)
-    Job.expects(:new).with(url: repository.html_url, status: 'pending', ip: '127.0.0.1').returns(job)
-    job.expects(:save).returns(true)
-    job.expects(:sync_issues_async).with(false, full: true).returns(true)
-
-    assert_equal job, repository.reconcile_async('127.0.0.1')
-  end
-
-  test "reconcile_async does not enqueue while reconciliation is pending or fresh" do
-    host = create_or_find_github_host
-    repository = create(:repository, host: host)
-
-    repository.expects(:acquire_reconciliation_slot).with('0.0.0.0').returns(false)
-    Job.expects(:new).never
-
-    assert_nil repository.reconcile_async
-  end
-
-  test "reconcile_async leaves a new repository to its initial full sync" do
-    host = create_or_find_github_host
-    repository = create(:repository, host: host, last_synced_at: nil)
-
-    repository.expects(:acquire_reconciliation_slot).never
-    Job.expects(:new).never
-
-    assert_nil repository.reconcile_async
-  end
-
-  test "reconciliation admission rate limits sources and caps pending jobs" do
-    host = create_or_find_github_host
-    repositories = 3.times.map { create(:repository, host: host) }
-    key_prefix = "issues:test:#{SecureRandom.hex}"
-    pending_key = "#{key_prefix}:pending"
-    source_keys = {
-      'source-a' => "#{key_prefix}:source:a",
-      'source-b' => "#{key_prefix}:source:b",
-      'source-c' => "#{key_prefix}:source:c",
-    }
-
-    repositories.each_with_index do |repository, index|
-      repository.stubs(:reconciliation_key).returns("#{key_prefix}:repository:#{index}")
-      repository.stubs(:reconciliation_pending_key).returns(pending_key)
-      source_keys.each do |source, key|
-        repository.stubs(:reconciliation_source_key).with(source).returns(key)
-      end
-      repository.stubs(:reconciliation_pending_ttl).returns(60)
-      repository.stubs(:reconciliation_pending_limit).returns(2)
-      repository.stubs(:reconciliation_source_interval).returns(60)
-      repository.stubs(:reconciliation_interval).returns(60)
-    end
-
-    REDIS.zadd(pending_key, 1, 'expired-repository')
-
-    assert repositories[0].acquire_reconciliation_slot('source-a')
-    assert_nil REDIS.zscore(pending_key, 'expired-repository')
-    assert_not repositories[1].acquire_reconciliation_slot('source-a')
-    assert repositories[1].acquire_reconciliation_slot('source-b')
-    assert_not repositories[2].acquire_reconciliation_slot('source-c')
-    assert_equal 2, REDIS.zcard(pending_key)
-
-    repositories[0].mark_reconciled
-
-    assert repositories[2].acquire_reconciliation_slot('source-c')
-    assert_equal 2, REDIS.zcard(pending_key)
-  ensure
-    REDIS.del(
-      pending_key,
-      *source_keys.values,
-      *repositories.each_index.map { |index| "#{key_prefix}:repository:#{index}" }
-    ) if key_prefix
-  end
-
-  test "reconcile_async clears its throttle when enqueueing fails" do
-    host = create_or_find_github_host
-    repository = create(:repository, host: host)
-    job = mock
-
-    repository.expects(:acquire_reconciliation_slot).returns(true)
-    repository.expects(:clear_reconciliation).once
-    Job.expects(:new).returns(job)
-    job.expects(:save).returns(true)
-    job.expects(:sync_issues_async).raises(StandardError.new('queue unavailable'))
-    Rails.logger.expects(:error).with("Failed to enqueue reconciliation for #{repository.full_name}: queue unavailable")
-
-    assert_nil repository.reconcile_async
   end
 
   test "issue_labels_count counts labels across issues" do

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -21,6 +21,7 @@ class RepositoryTest < ActiveSupport::TestCase
     host_api = mock
     host_api.expects(:load_issues).with(repository).yields([issue_data])
     host.expects(:host_instance).returns(host_api)
+    repository.expects(:mark_reconciled).once
 
     repository.sync_issues
 
@@ -108,6 +109,82 @@ class RepositoryTest < ActiveSupport::TestCase
     assert_in_delta expected_time_to_close, issue.time_to_close, 0.001
   end
 
+  test "reconcile inserts missing issues and refreshes author associations" do
+    host = create_or_find_github_host
+    repository = create(:repository, host: host, full_name: 'observablehq/notebook-kit')
+    create(
+      :issue,
+      repository: repository,
+      host: host,
+      uuid: '90',
+      number: 90,
+      user: 'mootari',
+      author_association: 'MEMBER',
+      created_at: 1.month.ago
+    )
+
+    issue_data = [21, 90, 91].map { |number| reconciled_issue_data(number) }
+    host_api = mock
+    host_api.expects(:load_issues).with(repository, full: true).yields(issue_data)
+    host.expects(:host_instance).returns(host_api)
+    repository.expects(:mark_reconciled).once
+
+    repository.reconcile
+
+    repository.reload
+    assert_equal [21, 90, 91], repository.issues.where(user: 'mootari').order(:number).pluck(:number)
+    assert_equal 3, repository.issues_count
+    assert_empty repository.issues.maintainers.where(user: 'mootari')
+  end
+
+  test "reconcile_async enqueues one full sync" do
+    host = create_or_find_github_host
+    repository = create(:repository, host: host)
+    job = mock
+
+    REDIS.expects(:set).with(repository.reconciliation_key, 'pending', nx: true, ex: 1.day.to_i).returns(true)
+    Job.expects(:new).with(url: repository.html_url, status: 'pending', ip: '127.0.0.1').returns(job)
+    job.expects(:save).returns(true)
+    job.expects(:sync_issues_async).with(false, full: true).returns(true)
+
+    assert_equal job, repository.reconcile_async('127.0.0.1')
+  end
+
+  test "reconcile_async does not enqueue while reconciliation is pending or fresh" do
+    host = create_or_find_github_host
+    repository = create(:repository, host: host)
+
+    REDIS.expects(:set).with(repository.reconciliation_key, 'pending', nx: true, ex: 1.day.to_i).returns(false)
+    Job.expects(:new).never
+
+    assert_nil repository.reconcile_async
+  end
+
+  test "reconcile_async leaves a new repository to its initial full sync" do
+    host = create_or_find_github_host
+    repository = create(:repository, host: host, last_synced_at: nil)
+
+    REDIS.expects(:set).never
+    Job.expects(:new).never
+
+    assert_nil repository.reconcile_async
+  end
+
+  test "reconcile_async clears its throttle when enqueueing fails" do
+    host = create_or_find_github_host
+    repository = create(:repository, host: host)
+    job = mock
+
+    REDIS.expects(:set).returns(true)
+    REDIS.expects(:del).with(repository.reconciliation_key).once
+    Job.expects(:new).returns(job)
+    job.expects(:save).returns(true)
+    job.expects(:sync_issues_async).raises(StandardError.new('queue unavailable'))
+    Rails.logger.expects(:error).with("Failed to enqueue reconciliation for #{repository.full_name}: queue unavailable")
+
+    assert_nil repository.reconcile_async
+  end
+
   test "issue_labels_count counts labels across issues" do
     host = create(:host)
     repository = create(:repository, host: host)
@@ -175,5 +252,27 @@ class RepositoryTest < ActiveSupport::TestCase
     result = repository.pull_request_authors.to_h
     assert_nil result['issue_author']
     assert_equal 1, result['pr_author']
+  end
+
+  def reconciled_issue_data(number)
+    {
+      uuid: number.to_s,
+      node_id: "node-#{number}",
+      number: number,
+      state: 'closed',
+      title: "Issue #{number}",
+      locked: false,
+      comments_count: 0,
+      created_at: 1.month.ago,
+      updated_at: Time.current,
+      closed_at: 1.day.ago,
+      user: 'mootari',
+      labels: [],
+      assignees: [],
+      pull_request: false,
+      author_association: 'NONE',
+      state_reason: 'completed',
+      merged_at: nil
+    }
   end
 end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -142,7 +142,7 @@ class RepositoryTest < ActiveSupport::TestCase
     repository = create(:repository, host: host)
     job = mock
 
-    REDIS.expects(:set).with(repository.reconciliation_key, 'pending', nx: true, ex: 1.day.to_i).returns(true)
+    repository.expects(:acquire_reconciliation_slot).with('127.0.0.1').returns(true)
     Job.expects(:new).with(url: repository.html_url, status: 'pending', ip: '127.0.0.1').returns(job)
     job.expects(:save).returns(true)
     job.expects(:sync_issues_async).with(false, full: true).returns(true)
@@ -154,7 +154,7 @@ class RepositoryTest < ActiveSupport::TestCase
     host = create_or_find_github_host
     repository = create(:repository, host: host)
 
-    REDIS.expects(:set).with(repository.reconciliation_key, 'pending', nx: true, ex: 1.day.to_i).returns(false)
+    repository.expects(:acquire_reconciliation_slot).with('0.0.0.0').returns(false)
     Job.expects(:new).never
 
     assert_nil repository.reconcile_async
@@ -164,10 +164,54 @@ class RepositoryTest < ActiveSupport::TestCase
     host = create_or_find_github_host
     repository = create(:repository, host: host, last_synced_at: nil)
 
-    REDIS.expects(:set).never
+    repository.expects(:acquire_reconciliation_slot).never
     Job.expects(:new).never
 
     assert_nil repository.reconcile_async
+  end
+
+  test "reconciliation admission rate limits sources and caps pending jobs" do
+    host = create_or_find_github_host
+    repositories = 3.times.map { create(:repository, host: host) }
+    key_prefix = "issues:test:#{SecureRandom.hex}"
+    pending_key = "#{key_prefix}:pending"
+    source_keys = {
+      'source-a' => "#{key_prefix}:source:a",
+      'source-b' => "#{key_prefix}:source:b",
+      'source-c' => "#{key_prefix}:source:c",
+    }
+
+    repositories.each_with_index do |repository, index|
+      repository.stubs(:reconciliation_key).returns("#{key_prefix}:repository:#{index}")
+      repository.stubs(:reconciliation_pending_key).returns(pending_key)
+      source_keys.each do |source, key|
+        repository.stubs(:reconciliation_source_key).with(source).returns(key)
+      end
+      repository.stubs(:reconciliation_pending_ttl).returns(60)
+      repository.stubs(:reconciliation_pending_limit).returns(2)
+      repository.stubs(:reconciliation_source_interval).returns(60)
+      repository.stubs(:reconciliation_interval).returns(60)
+    end
+
+    REDIS.zadd(pending_key, 1, 'expired-repository')
+
+    assert repositories[0].acquire_reconciliation_slot('source-a')
+    assert_nil REDIS.zscore(pending_key, 'expired-repository')
+    assert_not repositories[1].acquire_reconciliation_slot('source-a')
+    assert repositories[1].acquire_reconciliation_slot('source-b')
+    assert_not repositories[2].acquire_reconciliation_slot('source-c')
+    assert_equal 2, REDIS.zcard(pending_key)
+
+    repositories[0].mark_reconciled
+
+    assert repositories[2].acquire_reconciliation_slot('source-c')
+    assert_equal 2, REDIS.zcard(pending_key)
+  ensure
+    REDIS.del(
+      pending_key,
+      *source_keys.values,
+      *repositories.each_index.map { |index| "#{key_prefix}:repository:#{index}" }
+    ) if key_prefix
   end
 
   test "reconcile_async clears its throttle when enqueueing fails" do
@@ -175,8 +219,8 @@ class RepositoryTest < ActiveSupport::TestCase
     repository = create(:repository, host: host)
     job = mock
 
-    REDIS.expects(:set).returns(true)
-    REDIS.expects(:del).with(repository.reconciliation_key).once
+    repository.expects(:acquire_reconciliation_slot).returns(true)
+    repository.expects(:clear_reconciliation).once
     Job.expects(:new).returns(job)
     job.expects(:save).returns(true)
     job.expects(:sync_issues_async).raises(StandardError.new('queue unavailable'))

--- a/test/sidekiq/sync_issues_worker_test.rb
+++ b/test/sidekiq/sync_issues_worker_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class SyncIssuesWorkerTest < ActiveSupport::TestCase
+  test 'perform passes full reconciliation to the job' do
+    job = mock
+    Job.expects(:find_by_id!).with('job-id').returns(job)
+    job.expects(:perform_issue_syncing).with(true)
+
+    SyncIssuesWorker.new.perform('job-id', true)
+  end
+end

--- a/test/tasks/issues_rake_test.rb
+++ b/test/tasks/issues_rake_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+require 'rake'
+
+class IssuesRakeTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.load_tasks unless Rake::Task.task_defined?('issues:reconcile')
+    @task = Rake::Task['issues:reconcile']
+    @task.reenable
+  end
+
+  test 'reconcile performs a full repository reconciliation' do
+    host = create_or_find_github_host
+    repository = create(:repository, host: host, full_name: 'observablehq/notebook-kit')
+    Repository.any_instance.expects(:reconcile).once
+
+    output, = capture_io { @task.invoke('GitHub', repository.full_name) }
+
+    assert_includes output, "Reconciled #{repository.full_name}"
+  end
+
+  test 'reconcile aborts without repository arguments' do
+    assert_raises(SystemExit) do
+      capture_io { @task.invoke }
+    end
+  end
+end


### PR DESCRIPTION
Refresh GitHub issue metadata through a throttled full reconciliation when a repository is viewed. This updates stored `author_association` values, restores issues missed by GH Archive, and imports every API page.

Redis admits reconciliation jobs atomically, limited to one per source every five minutes and 20 pending jobs globally. Completed, failed, and expired jobs release their slots.

Add `issues:reconcile` for targeted repairs. No database schema change is needed.

Fixes #803.