### PR TITLE
Return pending responses while issues sync

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -5,4 +5,15 @@ class Api::V1::ApplicationController < ApplicationController
   def set_api_cache_headers
     set_cache_headers(cdn_ttl: 1.hour)
   end
+
+  def render_pending_repository(repository)
+    response.cache_control.replace(no_store: true)
+    response.headers['Retry-After'] = '60'
+
+    render json: {
+      status: 'pending',
+      repository_url: api_v1_host_repository_url(repository.host, repository),
+      issues_url: api_v1_host_repository_issues_url(repository.host, repository)
+    }, status: :accepted
+  end
 end

--- a/app/controllers/api/v1/issues_controller.rb
+++ b/app/controllers/api/v1/issues_controller.rb
@@ -2,7 +2,18 @@ class Api::V1::IssuesController < Api::V1::ApplicationController
   before_action :find_host
 
   def index
-    @repository = @host.repositories.find_by!('lower(full_name) = ?', params[:repository_id].downcase)
+    @repository = @host.repositories.find_by('lower(full_name) = ?', params[:repository_id].downcase)
+
+    unless @repository
+      owner = params[:repository_id].split('/').first
+      raise ActiveRecord::RecordNotFound if @host.owner_hidden?(owner)
+
+      @host.sync_repository_async(params[:repository_id], request.remote_ip, params[:priority].present?)
+      @repository = @host.repositories.find_by('lower(full_name) = ?', params[:repository_id].downcase)
+      raise ActiveRecord::RecordNotFound unless @repository
+    end
+
+    return render_pending_repository(@repository) if @repository.sync_pending?
 
     scope = @repository.issues
 

--- a/app/controllers/api/v1/repositories_controller.rb
+++ b/app/controllers/api/v1/repositories_controller.rb
@@ -32,15 +32,22 @@ class Api::V1::RepositoriesController < Api::V1::ApplicationController
     @repository = @host.repositories.find_by('lower(full_name) = ?', path.downcase)
     if @repository
       @repository.sync_async(request.remote_ip, priority) unless @repository.last_synced_at.present? && @repository.last_synced_at > 1.day.ago
+      return render_pending_repository(@repository) if @repository.sync_pending?
+
       redirect_to api_v1_host_repository_path(@host, @repository)
     else
       @host.sync_repository_async(path, request.remote_ip, priority) if path.present?
-      redirect_to api_v1_host_repository_path(@host, path)
+      @repository = @host.repositories.find_by('lower(full_name) = ?', path.downcase)
+      raise ActiveRecord::RecordNotFound unless @repository
+
+      render_pending_repository(@repository)
     end
   end
 
   def show
     @repository = @host.repositories.find_by!('lower(full_name) = ?', params[:id].downcase)
+    return render_pending_repository(@repository) if @repository.sync_pending?
+
     @repository.reconcile_async(request.remote_ip)
     fresh_when @repository, public: true
     @maintainers = @repository.issues.maintainers.group(:user).count.sort_by{|k,v| -v }

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -80,6 +80,10 @@ class Repository < ApplicationRecord
     host.kind.casecmp?('github')
   end
 
+  def sync_pending?
+    status.nil? && last_synced_at.nil?
+  end
+
   def sync_details
     conn = EcosystemsApiClient.client(repos_api_url)
     response = conn.get

--- a/test/controllers/api/v1/issues_controller_test.rb
+++ b/test/controllers/api/v1/issues_controller_test.rb
@@ -20,6 +20,60 @@ class Api::V1::IssuesControllerTest < ActionDispatch::IntegrationTest
     assert json.size >= 3
   end
 
+  test 'index creates an unknown repository and returns accepted' do
+    SyncIssuesWorker.expects(:perform_async).with(anything).returns('fake-job-id')
+
+    assert_difference 'Repository.count', 1 do
+      get api_v1_host_repository_issues_path(@host, 'new/repository'), as: :json
+    end
+
+    assert_response :accepted
+    repository = @host.repositories.find_by!(full_name: 'new/repository')
+    response_json = JSON.parse(response.body)
+    assert_equal 'pending', response_json['status']
+    assert_equal api_v1_host_repository_url(@host, repository), response_json['repository_url']
+    assert_equal api_v1_host_repository_issues_url(@host, repository), response_json['issues_url']
+    assert_equal '60', response.headers['Retry-After']
+    assert_includes response.headers['Cache-Control'], 'no-store'
+    refute_match(/public|max-age|s-maxage/, response.headers['Cache-Control'])
+  end
+
+  test 'index returns accepted for an existing repository that has not synced' do
+    repository = create_repository(@host, full_name: 'pending/repository', last_synced_at: nil)
+    SyncIssuesWorker.expects(:perform_async).never
+
+    get api_v1_host_repository_issues_path(@host, repository), as: :json
+
+    assert_response :accepted
+    assert_equal 'pending', JSON.parse(response.body)['status']
+  end
+
+  test 'index returns success for a synced repository with no issues' do
+    repository = create_repository(
+      @host,
+      full_name: 'empty/repository',
+      last_synced_at: Time.current,
+      issues_count: 0,
+      pull_requests_count: 0
+    )
+
+    get api_v1_host_repository_issues_path(@host, repository), as: :json
+
+    assert_response :success
+    assert_equal [], JSON.parse(response.body)
+  end
+
+  test 'index does not create a repository for a hidden owner' do
+    Owner.create!(host: @host, login: 'hidden-owner', hidden: true)
+    SyncIssuesWorker.expects(:perform_async).never
+
+    assert_no_difference 'Repository.count' do
+      get api_v1_host_repository_issues_path(@host, 'hidden-owner/private-repository'), as: :json
+    end
+
+    assert_response :not_found
+  end
+
   test 'index filters by created_after' do
     old_issue = create_issue(@repository, number: 200, created_at: 1.year.ago)
     new_issue = create_issue(@repository, number: 201, created_at: 1.day.ago)

--- a/test/controllers/api/v1/repositories_controller_test.rb
+++ b/test/controllers/api/v1/repositories_controller_test.rb
@@ -132,6 +132,20 @@ class Api::V1::RepositoriesControllerTest < ActionDispatch::IntegrationTest
     assert json['active_maintainers'].is_a?(Array)
   end
 
+  test 'show returns accepted while a repository is pending' do
+    repository = create_repository(@host, full_name: 'pending/repository', last_synced_at: nil)
+
+    get api_v1_host_repository_path(@host, repository), as: :json
+
+    assert_response :accepted
+    response_json = JSON.parse(response.body)
+    assert_equal 'pending', response_json['status']
+    assert_equal api_v1_host_repository_url(@host, repository), response_json['repository_url']
+    assert_equal api_v1_host_repository_issues_url(@host, repository), response_json['issues_url']
+    assert_equal '60', response.headers['Retry-After']
+    assert_includes response.headers['Cache-Control'], 'no-store'
+  end
+
   test 'show handles repository with different case' do
     get api_v1_host_repository_path(@host, @repository.full_name.upcase)
     assert_response :success
@@ -178,7 +192,40 @@ class Api::V1::RepositoriesControllerTest < ActionDispatch::IntegrationTest
       get api_v1_repositories_lookup_path, params: { url: url }
     end
     
-    assert_redirected_to api_v1_host_repository_path(@host, full_name)
+    assert_response :accepted
+    repository = @host.repositories.find_by!(full_name: full_name)
+    response_json = JSON.parse(response.body)
+    assert_equal 'pending', response_json['status']
+    assert_equal api_v1_host_repository_url(@host, repository), response_json['repository_url']
+    assert_equal api_v1_host_repository_issues_url(@host, repository), response_json['issues_url']
+    assert_equal '60', response.headers['Retry-After']
+    assert_includes response.headers['Cache-Control'], 'no-store'
+  end
+
+  test 'lookup returns accepted for a repository that has not synced' do
+    repository = create_repository(@host, full_name: 'pending/lookup-repository', last_synced_at: nil)
+    SyncIssuesWorker.expects(:perform_async).with(anything).returns('fake-job-id')
+
+    get api_v1_repositories_lookup_path, params: { url: repository.html_url }
+
+    assert_response :accepted
+    response_json = JSON.parse(response.body)
+    assert_equal 'pending', response_json['status']
+    assert_equal api_v1_host_repository_url(@host, repository), response_json['repository_url']
+    assert_equal api_v1_host_repository_issues_url(@host, repository), response_json['issues_url']
+  end
+
+  test 'lookup does not create a repository for a hidden owner' do
+    Owner.create!(host: @host, login: 'hidden-owner', hidden: true)
+    SyncIssuesWorker.expects(:perform_async).never
+
+    assert_no_difference 'Repository.count' do
+      get api_v1_repositories_lookup_path,
+        params: { url: 'https://github.com/hidden-owner/private-repository' },
+        as: :json
+    end
+
+    assert_response :not_found
   end
 
   test 'lookup does not sync recently synced repository' do

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -1,6 +1,24 @@
 require 'test_helper'
 
 class RepositoryTest < ActiveSupport::TestCase
+  test "sync_pending? is true before a repository completes its first sync" do
+    repository = create(:repository, last_synced_at: nil)
+
+    assert_predicate repository, :sync_pending?
+  end
+
+  test "sync_pending? is false for a synced repository with no issues" do
+    repository = create(:repository, last_synced_at: Time.current, issues_count: 0, pull_requests_count: 0)
+
+    refute_predicate repository, :sync_pending?
+  end
+
+  test "sync_pending? is false for a repository with a terminal status" do
+    repository = create(:repository, status: 'not_found', last_synced_at: nil)
+
+    refute_predicate repository, :sync_pending?
+  end
+
   test "successful issue sync leaves repository active and visible" do
     host = create(:host)
     repository = create(:repository, host: host, status: 'error', last_synced_at: nil)


### PR DESCRIPTION
Return `202 Accepted` while a repository is being indexed for issues. Pending responses include stable polling URLs, `Retry-After`, and `Cache-Control: no-store`; synced empty repositories still return `200`.

Part of ecosyste-ms/commits#986.