### PR TITLE
Reject incomplete issue repository paths

### DIFF
--- a/app/controllers/api/v1/issues_controller.rb
+++ b/app/controllers/api/v1/issues_controller.rb
@@ -2,10 +2,13 @@ class Api::V1::IssuesController < Api::V1::ApplicationController
   before_action :find_host
 
   def index
+    repository_parts = params[:repository_id].split('/', -1)
+    raise ActiveRecord::RecordNotFound if repository_parts.size < 2 || repository_parts.any?(&:blank?)
+
     @repository = @host.repositories.find_by('lower(full_name) = ?', params[:repository_id].downcase)
 
     unless @repository
-      owner = params[:repository_id].split('/').first
+      owner = repository_parts.first
       raise ActiveRecord::RecordNotFound if @host.owner_hidden?(owner)
 
       @host.sync_repository_async(params[:repository_id], request.remote_ip, params[:priority].present?)

--- a/test/controllers/api/v1/issues_controller_test.rb
+++ b/test/controllers/api/v1/issues_controller_test.rb
@@ -74,6 +74,16 @@ class Api::V1::IssuesControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test 'index does not create a repository for an incomplete repository path' do
+    SyncIssuesWorker.expects(:perform_async).never
+
+    assert_no_difference 'Repository.count' do
+      get api_v1_host_repository_issues_path(@host, 'owner'), as: :json
+    end
+
+    assert_response :not_found
+  end
+
   test 'index filters by created_after' do
     old_issue = create_issue(@repository, number: 200, created_at: 1.year.ago)
     new_issue = create_issue(@repository, number: 201, created_at: 1.day.ago)


### PR DESCRIPTION
Reject issue-list requests whose repository identifier has fewer than two nonblank path segments. This prevents invalid repository rows and sync jobs from requests such as `/repositories/owner/issues`.

Follow-up to #845 and ecosyste-ms/commits#1000.