### PR TITLE
Prevent caching not found repository responses

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,5 +1,7 @@
 class ErrorsController < ApplicationController
   def not_found
+    response.cache_control.replace(no_store: true)
+
     respond_to do |format|
       format.html { render status: :not_found }
       format.json { render json: { error: "not found" }, status: :not_found }

--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -1,10 +1,12 @@
 require 'test_helper'
 
 class ErrorsControllerTest < ActionDispatch::IntegrationTest
-  test 'renders 404' do
+  test 'renders 404 without caching it' do
     get '/404'
     assert_response :not_found
     assert_template 'errors/not_found'
+    assert_includes response.headers['Cache-Control'], 'no-store'
+    refute_match(/public|max-age|s-maxage/, response.headers['Cache-Control'])
   end
 
   test 'renders 422' do


### PR DESCRIPTION
Repository polling URLs could return a cached `404` after a missing repository was created by a sync request. Mark `404` responses as `no-store` so later polling requests can observe pending and completed repository states.

This matches the pending response handling added in #845 and #846.